### PR TITLE
fix: change the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta name="robots" content="nofollow">
     <!-- Website information -->
-    <title>【公式】コンピュータ研究会・WINC｜早稲田大学公認のインカレプログラミングサークル</title>
+    <title>【公式】コンピュータ研究会・WINC｜慶應義塾大学公認のインカレプログラミングサークル</title>
     <meta name="description"
         content="コンピュータ研究会・WINCは、1967年創立の早稲田大学公認インカレプログラミングサークルです。HPチーム、セキュリティチーム、競プロチーム、Pythonチーム、プロジェクションマッピングチームの5つの部門に分かれてIT知識を楽しく勉強しています。大学・学年・経験不問で、多様性溢れるメンバーが揃っています。">
     <meta name="keywords" content="早稲田大学,プログラミング,デザイン,コンピュータ,サークル,初心者">


### PR DESCRIPTION
タイトルの一部修正
「早稲田大学」➝「慶應義塾大学」